### PR TITLE
Troubleshoot how config files are parsed

### DIFF
--- a/CGATCore/Pipeline/Control.py
+++ b/CGATCore/Pipeline/Control.py
@@ -155,11 +155,11 @@ def print_config_files():
         Priority 1 is the highest.
     '''
 
-    filenames = get_params()['pipeline_ini']
-    print("\n List of .ini files used to configure the pipeline")
+    filenames = get_params()['pipeline_ini'] + get_params()['pipeline_yml']
+    print("\n List of config files used to configure the pipeline")
     s = len(filenames)
     if s == 0:
-        print(" No ini files passed!")
+        print(" No config files passed!")
     elif s >= 1:
         print(" %-11s: %s " % ("Priority", "File"))
         for f in filenames:

--- a/CGATCore/Pipeline/Parameters.py
+++ b/CGATCore/Pipeline/Parameters.py
@@ -15,8 +15,6 @@ import configparser
 import getpass
 import logging
 import yaml
-import re
-from collections import defaultdict
 
 import CGATCore.Experiment as E
 import CGATCore.IOTools as IOTools
@@ -53,7 +51,7 @@ class TriggeredDefaultFactory:
 # Global variable for parameter interpolation in commands
 # This is a dictionary that can be switched between defaultdict
 # and normal dict behaviour.
-PARAMS = defaultdict(TriggeredDefaultFactory())
+PARAMS = collections.defaultdict(TriggeredDefaultFactory())
 
 # patch - if --help or -h in command line arguments,
 # switch to a default dict to avoid missing paramater
@@ -137,7 +135,7 @@ def config_to_dictionary(config):
         A dictionary of configuration values
 
     """
-    p = defaultdict(lambda: defaultdict(TriggeredDefaultFactory()))
+    p = {}
     for section in config.sections():
         for key, value in config.items(section):
             try:
@@ -149,10 +147,6 @@ def config_to_dictionary(config):
                 raise
 
             p["%s_%s" % (section, key)] = v
-
-            # IMS: new heirarchical format
-            p[section][key] = v
-
             if section in ("general", "DEFAULT"):
                 p["%s" % (key)] = v
 
@@ -160,19 +154,6 @@ def config_to_dictionary(config):
         p["%s" % (key)] = IOTools.str2val(value)
 
     return p
-
-
-def nested_update(old, new):
-    '''Update potentially nested dictionaries. If both old[x] and new[x]
-    inherit from collections.Mapping, then update old[x] with entries from
-    new[x], otherwise set old[x] to new[x]'''
-
-    for key, value in new.items():
-        if isinstance(value, collections.Mapping) and \
-           isinstance(old.get(key, str()), collections.Mapping):
-            old[key].update(new[key])
-        else:
-            old[key] = new[key]
 
 
 def input_validation(PARAMS, pipeline_script=""):
@@ -324,9 +305,9 @@ def get_parameters(filenames=None,
     filenames = [x.strip() for x in filenames]
 
     # update with hard-coded PARAMS
-    nested_update(PARAMS, HARDCODED_PARAMS)
+    PARAMS.update(HARDCODED_PARAMS)
     if defaults:
-        nested_update(PARAMS, defaults)
+        PARAMS.update(defaults)
 
     # reset working directory. Set in PARAMS to prevent repeated calls to
     # os.getcwd() failing if network is busy
@@ -342,7 +323,6 @@ def get_parameters(filenames=None,
     yml_filenames = [x for x in filenames if not x.endswith(".ini")]
 
     if ini_filenames:
-
         conf = configparser.SafeConfigParser()
         try:
             conf.read(ini_filenames)
@@ -358,9 +338,8 @@ def get_parameters(filenames=None,
             config = configparser.RawConfigParser()
             config.read(ini_filenames)
             p = config_to_dictionary(config)
-
         if p:
-            nested_update(PARAMS, p)
+            PARAMS.update(p)
 
     if yml_filenames:
         for filename in yml_filenames:
@@ -372,7 +351,7 @@ def get_parameters(filenames=None,
             with open(filename) as inf:
                 p = yaml.load(inf)
                 if p:
-                    nested_update(PARAMS, p)
+                    PARAMS.update(p)
 
     # for backwards compatibility - normalize dictionaries
     p = {}
@@ -380,7 +359,7 @@ def get_parameters(filenames=None,
         if isinstance(v, collections.Mapping):
             for kk, vv in v.items():
                 p["{}_{}".format(k, kk)] = vv
-    nested_update(PARAMS, p)
+    PARAMS.update(p)
                 
     # interpolate some params with other parameters
     for param in INTERPOLATE_PARAMS:

--- a/CGATCore/Pipeline/Parameters.py
+++ b/CGATCore/Pipeline/Parameters.py
@@ -235,6 +235,15 @@ def get_parameters(filenames=None,
     '''read one or more config files and build global PARAMS configuration
     dictionary.
 
+    Different config files have different priorities:
+    * highest -> ordered list of given .yml files
+    * then    -> pipeline.ini in working directory
+    * then    -> ~/.cgat
+    * lowest  -> default pipeline.ini in config file
+
+    Higher priority files will overwrite configuration of lower priority ones.
+    If in doubt, please use "printconfig" to see priority.
+
     Arguments
     ---------
     filenames : list
@@ -302,12 +311,14 @@ def get_parameters(filenames=None,
                               userfile)
             if os.path.exists(fn):
                 # priority is:
-                # highest -> pipeline.ini in working directory
-                # then    -> ~/.cgat or ~/.cgat.yml
+                # highest -> ordered list of given .yml files
+                # then    -> pipeline.ini in working directory
+                # then    -> ~/.cgat
                 # lowest  -> default pipeline.ini in config file
+                # if in doubt, use "printconfig" to see priority
                 if 'pipeline.ini' in filenames:
                     index = filenames.index('pipeline.ini')
-                    filenames.insert(index,fn)
+                    filenames.insert(index, fn)
                 else:
                     filenames.append(fn)
 

--- a/CGATCore/Pipeline/Parameters.py
+++ b/CGATCore/Pipeline/Parameters.py
@@ -302,7 +302,7 @@ def get_parameters(filenames=None,
         if os.path.exists(fn):
             filenames.insert(0, fn)
 
-    filenames = [x.strip() for x in filenames]
+    filenames = [x.strip() for x in filenames if os.path.exists(x)]
 
     # update with hard-coded PARAMS
     PARAMS.update(HARDCODED_PARAMS)
@@ -320,7 +320,9 @@ def get_parameters(filenames=None,
 
     # backwards compatibility - read ini files
     ini_filenames = [x for x in filenames if x.endswith(".ini")]
+    PARAMS["pipeline_ini"] = ini_filenames
     yml_filenames = [x for x in filenames if not x.endswith(".ini")]
+    PARAMS["pipeline_yml"] = yml_filenames
 
     if ini_filenames:
         conf = configparser.SafeConfigParser()


### PR DESCRIPTION

This PR tries to fix https://github.com/cgat-developers/cgat-core/issues/18

Specifically:
* updated the `printconfig` method to print both ini and yml files in correct priority order
* updated the code to handle nested dictionaries in PARAMS correctly
* for backward compatibility, `~/.cgat` (ini) files are parsed again
