### PR TITLE
Make enforcing memory restrictions via ulimit optional

### DIFF
--- a/CGATCore/Pipeline/Execution.py
+++ b/CGATCore/Pipeline/Execution.py
@@ -620,7 +620,7 @@ class Executor(object):
 
             tmpfile.write("\ntrap clean_all EXIT\n\n")
 
-            if self.job_memory != "unlimited" and self.job_memory != "etc":
+            if self.job_memory != "unlimited" and self.job_memory != "etc" and get_params()["cluster_memory_ulimit"]:
                 # restrict virtual memory
                 # Note that there are resources in SGE which could do this directly
                 # such as v_hmem.

--- a/CGATCore/Pipeline/Parameters.py
+++ b/CGATCore/Pipeline/Parameters.py
@@ -86,6 +86,9 @@ HARDCODED_PARAMS = {
         'memory_resource': "mem_free",
         # amount of memory set by default for each job
         'memory_default': "4G",
+        # ensure requested memory is not exceeded via ulimit (this is
+        # not compatible with and/or needed  for all cluster configurations)
+        'memory_ulimit': True,
         # general cluster options
         'options': "",
         # parallel environment to use for multi-threaded jobs
@@ -386,7 +389,7 @@ def get_parameters(filenames=None,
             for kk, vv in v.items():
                 p["{}_{}".format(k, kk)] = vv
     nested_update(PARAMS, p)
-                
+
     # interpolate some params with other parameters
     for param in INTERPOLATE_PARAMS:
         try:


### PR DESCRIPTION
This is done via a new boolean parameter "cluster_memory_ulimit".

Use of ulimit is problematic with some cluster configurations (e.g. SLURM) and not necessary if memory is already controlled with the queue manager (as can be done with e.g. SLURM).