### PR TITLE
Docs: switch sansomlab/scseq -> sansomlab/tenx

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,13 +26,13 @@ Conda
 
 CGAT-core is a workflow management system that allows users to quickly and reproducibly build scalable
 data analysis pipelines. CGAT-core is  a set of libraries and helper functions used to enable researchers
-to design and build computational workflows for the analysis of large-scale data-analysis. 
+to design and build computational workflows for the analysis of large-scale data-analysis.
 
 Used in combination with CGAT-apps, we have deomonstrated the functionality of our
-flexible implementation using a set of well documented, easy to install and easy to use workflows, 
+flexible implementation using a set of well documented, easy to install and easy to use workflows,
 called CGAT-flow.
 
-CGAT-core is open-sourced, powerful and user-friendly, and has been continually developed 
+CGAT-core is open-sourced, powerful and user-friendly, and has been continually developed
 as a Next Generation Sequencing (NGS) workflow management system over the past 10 years.
 
 
@@ -50,10 +50,10 @@ To be added....
 Support
 -------
 
-- Please refer to our :ref:`FAQ` section 
+- Please refer to our :ref:`FAQ` section
 - In case of questions, please add these to `stack overflow <https://stackoverflow.com/search?q=cgat>`_
 - For bugs and issues, please raise an issue on `github <https://github.com/cgat-developers/cgat-core>`_
-- For contributions, please refer to our contributor section and `github <https://github.com/cgat-developers/cgat-core>`_ source code. 
+- For contributions, please refer to our contributor section and `github <https://github.com/cgat-developers/cgat-core>`_ source code.
 
 --------
 Examples
@@ -62,7 +62,7 @@ Examples
 **CGAT-flow**
    As an example of the flexibility and functionality of CGAT-core, we have developed a set of fully tested production pipelines for automating the analysis of our NGS data. Please refer to the `github <https://github.com/cgat-developers/cgat-flow>`_ page for information on how to install and use our code.
 **Single cell RNA-seq**
-   The sansom lab use the CGAT-core workflow engine to develop single cell `sequencing analysis workflows <https://github.com/sansomlab/scseq>`_. 
+   The sansom lab use the CGAT-core workflow engine to develop single cell `sequencing analysis workflows <https://github.com/sansomlab/tenx>`_.
 
 
 -------------------------------------


### PR DESCRIPTION
The "tenx" pipelines are written with cgat-core.

(scseq is an older repo for analysis of smart-seq2 data that is not
yet ported over)