### PR TITLE
Read in tables as generators rather than lists. Large memory saving

### DIFF
--- a/CGATCore/Tables.py
+++ b/CGATCore/Tables.py
@@ -195,22 +195,25 @@ def join_tables(outfile, options, args):
 
         lines = read_table(filename, options)
 
-        # skip (or not skip) empty tables
-        #https://nelsonslog.wordpress.com/2016/04/06/python3-no-len-for-iterators/
-        if sum(1 for e in lines) == 0 and options.ignore_empty:
-            E.warn("%s is empty - skipped" % filename)
-            headers_to_delete.append(nindex)
-            continue
+        try:
+            # check if the table is empty
+            data = next(lines).split()
+        except StopIteration:
+            # an empty table will raise a StopIteration
+            # skip (or not skip) empty tables
+            if options.ignore_empty:
+                E.warn("%s is empty - skipped" % filename)
+                headers_to_delete.append(nindex)
+                continue
 
         table = {}
         sizes = {}
         max_size = 0
         ncolumns = 0
 
-        lines = read_table(filename, options)
-
         if options.input_has_titles:
-            data = next(lines).split()
+            # See https://github.com/cgat-developers/cgat-core/pull/53
+            #data = next(lines).split()
             # no titles have been defined so far
             if not titles:
                 key = "-".join([data[x] for x in options.columns])

--- a/CGATCore/Tables.py
+++ b/CGATCore/Tables.py
@@ -196,7 +196,8 @@ def join_tables(outfile, options, args):
         lines = read_table(filename, options)
 
         # skip (or not skip) empty tables
-        if len(lines) == 0 and options.ignore_empty:
+        #https://nelsonslog.wordpress.com/2016/04/06/python3-no-len-for-iterators/
+        if sum(1 for e in lines) == 0 and options.ignore_empty:
             E.warn("%s is empty - skipped" % filename)
             headers_to_delete.append(nindex)
             continue
@@ -206,8 +207,10 @@ def join_tables(outfile, options, args):
         max_size = 0
         ncolumns = 0
 
+        lines = read_table(filename, options)
+
         if options.input_has_titles:
-            data = lines[0][:-1].split("\t")
+            data = next(lines)[0][:-1].split("\t")
             # no titles have been defined so far
             if not titles:
                 key = "-".join([data[x] for x in options.columns])
@@ -252,7 +255,6 @@ def join_tables(outfile, options, args):
                 else:
                     titles.append(data[x])
 
-            del lines[0]
         else:
 
             # set take based on numeric columns if no titles are present

--- a/CGATCore/Tables.py
+++ b/CGATCore/Tables.py
@@ -12,38 +12,40 @@ import CGATCore.Experiment as E
 
 
 def read_table(filename, options):
-    '''read table and filter.
+    '''read table and filter as an iterator.
     '''
 
     if os.path.exists(filename):
-        lines = IOTools.open_file(filename, "r").readlines()
+        lines = IOTools.open_file(filename, "r")
     else:
-        lines = []
+        lines = (x for x in [])
 
     # extract table by regular expression
+
+    enumerated_lines = enumerate(lines)
+    
     if options.regex_start:
         rx = re.compile(options.regex_start)
-        for n, line in enumerate(lines):
+        for n, line in enumerated_lines:
             if rx.search(line):
-                E.info("reading table from line %i/%i" % (n, len(lines)))
-                lines = lines[n:]
+                E.info("reading table from line %i" % n)
+                if not line.startswith("#") and line.strip():
+                    yield line
                 break
         else:
             E.info("start regex not found - no table")
-            lines = []
 
     if options.regex_end:
         rx = re.compile(options.regex_end)
-        for n, line in enumerate(lines):
-            if rx.search(line):
-                break
-        lines = lines[:n]
+        
+    for n, line in enumerated_lines:
 
-    # remove comments and empty lines
-    lines = [x for x in lines if not x.startswith("#") and x.strip()]
-
-    return lines
-
+        if options.regex_end and rx.search(line):
+            break
+        
+        if not line.startswith("#") and line.strip():
+            yield line
+        
 
 def concatenate_tables(outfile, options, args):
     '''concatenate tables.'''
@@ -62,11 +64,9 @@ def concatenate_tables(outfile, options, args):
     # read all tables
     for filename, header in zip(options.filenames, row_headers):
         table = read_table(filename, options)
-        if len(table) == 0:
-            E.warn("table '%s' is empty" % filename)
-            continue
         tables.append(table)
         headers.append(header)
+
     row_headers = headers
         
     if options.cat is None:
@@ -84,10 +84,21 @@ def concatenate_tables(outfile, options, args):
                 (len(row_headers[0]), len(row_head_titles)))
 
     # collect titles
+    first_lines = []
+    
+    for n, table in enumerate(tables):
+            try:
+                title_line = next(table)
+            except StopIteration:
+                E.warn("Empty table %s " % options.filenames[n])
+                first_lines.append(None)
+                continue
+            first_lines.append(title_line)
+
     if options.input_has_titles:
         titles = collections.OrderedDict()
-        for table in tables:
-            for key in table[0][:-1].split("\t"):
+        for title_line in first_lines:
+            for key in title_line[:-1].split("\t"):
                 # skip any titles that conflict with
                 # the newly added titles
                 if key in row_head_titles:
@@ -102,7 +113,7 @@ def concatenate_tables(outfile, options, args):
         for x, title in enumerate(titles.keys()):
             map_title2column[title] = x
     else:
-        ncolumns = [len(table[0].split('\t')) for table in tables]
+        ncolumns = [len(first_line.split('\t')) for first_line in first_lines]
         if min(ncolumns) != max(ncolumns):
             raise ValueError('tables have unequal number of columns '
                              '(min=%i, max=%i)' %
@@ -113,14 +124,12 @@ def concatenate_tables(outfile, options, args):
 
     all_titles = set(titles.keys())
     for nindex, table in enumerate(tables):
-        if options.input_has_titles:
-            titles = table[0][:-1].split("\t")
-            map_old2new = [map_title2column[t] for t in titles]
-            del table[0]
-        else:
-            map_old2new = list(range(len(all_titles)))
 
-        for l in table:
+        if first_lines[nindex] is None:
+            # table is empty
+            continue
+
+        def _output_line(l, map_old2new):
             data = [missing_value] * len(all_titles)
             for x, value in enumerate(l[:-1].split("\t")):
                 if map_old2new[x] is None:
@@ -131,6 +140,16 @@ def concatenate_tables(outfile, options, args):
             row = "\t".join([str(x) for x in row_headers[nindex]] +
                             data) + "\n"
             outfile.write(row)
+            
+        if options.input_has_titles:
+            titles = first_lines[nindex][:-1].split("\t")
+            map_old2new = [map_title2column[t] for t in titles]
+        else:
+            map_old2new = list(range(len(all_titles)))
+            _output_line(first_lines[nindex], map_old2new)
+
+        for l in table:
+            _output_line(l, map_old2new)
 
 
 def join_tables(outfile, options, args):

--- a/CGATCore/Tables.py
+++ b/CGATCore/Tables.py
@@ -210,7 +210,7 @@ def join_tables(outfile, options, args):
         lines = read_table(filename, options)
 
         if options.input_has_titles:
-            data = next(lines)[0][:-1].split("\t")
+            data = next(lines).split()
             # no titles have been defined so far
             if not titles:
                 key = "-".join([data[x] for x in options.columns])


### PR DESCRIPTION
This PR is to address #52. `CGATCore.Tables.read_tables` now returns a generator rather than a list of lines. 

It also alters `CGATCore.Tables.read_tables` to cope with this fact, which mostly requires siphoning off the first lines of each table and remembering to do the right thing with them later. 

I've left things be for `CGATCore.Tables.join_tables` by enclosing the call to `read_tables` in `list()`, as this function only reads one table at a time, however there are probably efficiencies to be made there as well.

I've not been able to test this beyond the dataset that was causing us problems to show that it still gives the same output as there aren't many tests associated with `CGATCore`. Therefore, a careful pair of eyes would be appreciated.

