### PR TITLE
return alternative value if benchmark data is None

### DIFF
--- a/cgatcore/pipeline/execution.py
+++ b/cgatcore/pipeline/execution.py
@@ -672,7 +672,7 @@ class Executor(object):
 
         def get_val(d, v, alt):
             val = d.get(v, alt)
-            if val == "unknown":
+            if val == "unknown" or val == None:
                 val = alt
             return val
         


### PR DESCRIPTION
Data collected for benchmarking can return `None` for e.g. `cpu_t`, `start_time` and `end_time` which results in a `TypeError`. 
See issue #83