### PR TITLE
Bugfix: use the `ruffus_return_dag` function defined in scope

### DIFF
--- a/cgatcore/pipeline/control.py
+++ b/cgatcore/pipeline/control.py
@@ -586,7 +586,7 @@ def parse_commandline(argv=None, optparse=True, **kwargs):
     """
     if argv is None:
         argv = sys.argv
-    
+
     if optparse is True:
 
         parser = E.OptionParser(version="%prog version: $Id$",
@@ -1371,7 +1371,7 @@ def run_workflow(args, argv=None, pipeline=None):
                         checksum_level=args.ruffus_checksums_level)
 
                 elif args.pipeline_action == "state":
-                    ruffus.ruffus_return_dag(
+                    ruffus_return_dag(
                         args.stdout,
                         target_tasks=args.pipeline_targets,
                         forcedtorun_tasks=forcedtorun_tasks,


### PR DESCRIPTION
Invoking a pipeline with the "state" option raises the following error:

```
Traceback (most recent call last):
  File "/ifs/projects/proj093/src/pipeline_cloneseq2.py", line 437, in <module>
    sys.exit(P.main(sys.argv))
  File "/ifs/devel/paulb/miniconda3/envs/cgatapps/lib/python3.7/site-packages/cgatcore/pipeline/control.py", line 1390, in main
    run_workflow(options, args)
  File "/ifs/devel/paulb/miniconda3/envs/cgatapps/lib/python3.7/site-packages/cgatcore/pipeline/control.py", line 1271, in run_workflow
    ruffus.ruffus_return_dag(
AttributeError: module 'ruffus' has no attribute 'ruffus_return_dag'
```

In other words, ruffus does not define a `ruffus_return_dag` function. 
However, 'rufus_return_dag` is defined in cgatcore/pipeline.py (i.e. in scope). So presumably that function is supposed to be called instead. 

Warning: solution is not tested, as I haven't managed to install cgatcore from source. 