### PR TITLE
 bugfix add_pipe_args in cgatcore.table

### DIFF
--- a/cgatcore/table.py
+++ b/cgatcore/table.py
@@ -480,7 +480,7 @@ def main(argv=None):
         invert_match=False,
     )
 
-    (args, unknown) = E.start(parser, add_pipe_args=True, unknowns=True)
+    (args, unknown) = E.start(parser, unknowns=True)
 
     args.parameters = args.parameters.split(",")
 


### PR DESCRIPTION
There is no `add_pipe_args` argument in E.start(), which is causing issues in `cgat-apps`.

The original code might mean `add_pipe_options`, which is `True` by default, so removing `add_pipe_args` entirely should fix the issue when using `cgatcore.table`.

This is causing problems on:
* https://github.com/cgat-developers/cgat-apps/pull/56
* https://github.com/cgat-developers/cgat-apps/pull/57
