### PR TITLE
Ac db

### DIFF
--- a/cgatcore/csv2db.py
+++ b/cgatcore/csv2db.py
@@ -60,7 +60,7 @@ def to_sql_pkey(self, frame, name, if_exists='fail', index=True,
                 raise ValueError('The type of %s is not a SQLAlchemy '
                                  'type ' % col)
 
-    table = pd.io.sql.SQLTable(name, self,
+    table = pandas.io.sql.SQLTable(name, self,
                                frame=frame,
                                index=index,
                                if_exists=if_exists,
@@ -68,7 +68,6 @@ def to_sql_pkey(self, frame, name, if_exists='fail', index=True,
                                schema=schema,
                                dtype=dtype, **kwargs)
     table.create()
-    table.insert(chunksize)
 
 
 def get_flavour(database_url):
@@ -157,12 +156,13 @@ def run(infile, options, chunk_size=10000):
                 else:
                     empty_columns = empty_columns.intersection(empty_list)
 
-            if not options.keys:
+            if options.keys:
                 pandas_sql = pandas.io.sql.pandasSQL_builder(dbhandle, schema=None)
+                E.info("here ==========")
 
                 to_sql_pkey(pandas_sql, df, tablename,
                             index=True, index_label=options.indices,
-                            keys=options.keys, if_exists='replace')            
+                            keys=" ".join(options.keys), if_exists='replace')
             
             else:
                 df.to_sql(tablename,

--- a/cgatcore/csv2db.py
+++ b/cgatcore/csv2db.py
@@ -52,8 +52,7 @@ def quote_tablename(name, quote_char="_", flavour="sqlite"):
 def to_sql_pkey(self, frame, name, if_exists='fail', index=True,
              index_label=None, schema=None,
              dtype=None, **kwargs):
-    '''Function to load a table with the reqirement for a primary key.
-       --add-index is also required for the primary key'''
+    '''Function to load a table with the reqirement for a primary key.'''
     if dtype is not None:
         from sqlalchemy.types import to_instance, TypeEngine
         for col, my_type in dtype.items():

--- a/cgatcore/csv2db.py
+++ b/cgatcore/csv2db.py
@@ -50,9 +50,10 @@ def quote_tablename(name, quote_char="_", flavour="sqlite"):
 
 
 def to_sql_pkey(self, frame, name, if_exists='fail', index=True,
-             index_label=None, schema=None, chunksize=None,
+             index_label=None, schema=None,
              dtype=None, **kwargs):
-    '''Function to load a table with the reqirement for a primary key'''
+    '''Function to load a table with the reqirement for a primary key.
+       --add-index is also required for the primary key'''
     if dtype is not None:
         from sqlalchemy.types import to_instance, TypeEngine
         for col, my_type in dtype.items():
@@ -68,6 +69,7 @@ def to_sql_pkey(self, frame, name, if_exists='fail', index=True,
                                schema=schema,
                                dtype=dtype, **kwargs)
     table.create()
+    table.insert()
 
 
 def get_flavour(database_url):
@@ -158,10 +160,9 @@ def run(infile, options, chunk_size=10000):
 
             if options.keys:
                 pandas_sql = pandas.io.sql.pandasSQL_builder(dbhandle, schema=None)
-                E.info("here ==========")
 
                 to_sql_pkey(pandas_sql, df, tablename,
-                            index=True, index_label=options.indices,
+                            index=True,
                             keys=" ".join(options.keys), if_exists='replace')
             
             else:
@@ -248,16 +249,6 @@ def buildParser():
                         help="force lower case column names "
                         )
 
-    # parser.add_argument("-u", "--ignore-duplicates", dest="ignore_duplicates",
-    #                   action="store_true",
-    #                   help="ignore columns with duplicate names "
-    #                   "[default=%default].")
-
-    # parser.add_argument("-s", "--ignore-same", dest="ignore_same",
-    #                   action="store_true",
-    #                   help="ignore columns with identical values "
-    #                   "[default=%default].")
-
     parser.add_argument("--chunk-size", dest="chunk_size", type=int,
                         help="chunk-size, upload table in block of rows "
                         )
@@ -278,11 +269,6 @@ def buildParser():
     parser.add_argument("-e", "--ignore-empty", dest="ignore_empty",
                         action="store_true",
                         help="ignore columns which are all empty ")
-
-    # parser.add_argument("-q", "--quick", dest="insert_quick",
-    #                   action="store_true",
-    #                   help="try quick file based import - needs to "
-    #                   "be supported by the backend [default=%default].")
 
     parser.add_argument("-i", "--add-index", dest="indices", type=str,
                         action="append",
@@ -320,7 +306,6 @@ def buildParser():
         lowercase_columns=False,
         tablename="csv",
         from_zipped=False,
-        ignore_duplicates=False,
         ignore_identical=False,
         ignore_empty=False,
         insert_many=False,
@@ -332,7 +317,6 @@ def buildParser():
         backend="sqlite",
         indices=[],
         missing_values=("na", "NA", ),
-        insert_quick=False,
         allow_empty=False,
         retry=False,
         utf=False,


### PR DESCRIPTION
Primary key functionality was missing from the database and csv2db script.

It wasn't an easy thing to fix because sqlite doesn't have full ALTER  TABLE functionality so it is impossible to add a primary key after the table is created.

As a workaround I have used the pandas.io.sql functions https://tedboy.github.io/pandas/_modules/pandas/io/sql.html to create a wrapper for pandasSQL_builder, which is the only way I can think of handling keys.

This has been tested using csv2db and primary keys are indeed now supported (sqlite3 PRAGMA table_info(table); command)

@snsansom if you have time to have a look at this then that would be great, otherwise I just merge the functionality in if test pass (for some reason push requests are failing but if pr passes then its good to go). This was holding me up creating the database for cellhub