### PR TITLE
Raise error if the job is aborted

### DIFF
--- a/cgatcore/pipeline/cluster.py
+++ b/cgatcore/pipeline/cluster.py
@@ -116,7 +116,7 @@ class DRMAACluster(object):
             error_msg = None
             if retval.exitStatus == 0:
                 if retval.wasAborted is True:
-                    get_logger().warning(
+                    error_msg = (
                         "Job {} has exit status 0, but marked as hasAborted=True, hasExited={} "
                         "(Job may have been cancelled by the user or the scheduler due to memory constraints)"
                         "The stderr was \n{}\nstatement = {}".format(


### PR DESCRIPTION
I am not sure why the behaviour was changed. It is mission-critical.

It is essential that pipelines raise an error if the job is cancelled by
the scheduler. A warning is not enough. It is not reasonable to expect people to check
the logs for warnings 100% of the time.

Jobs may be cancelled by the scheduler for exceeding memory limits and in such cases
this may result in incomplete output. Downstream tasks may still run, and the
incomplete output may go undetected but might change the outputs in a meaningful way,
which ultimately may lead to incorrect interpretation of data.