### PR TITLE
Fix python 3.10 support

### DIFF
--- a/.github/workflows/cgatcore_python.yml
+++ b/.github/workflows/cgatcore_python.yml
@@ -18,9 +18,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if conda/environments/cgat-core.yml has not changed
           CACHE_NUMBER: 0

--- a/.github/workflows/cgatcore_python.yml
+++ b/.github/workflows/cgatcore_python.yml
@@ -31,12 +31,12 @@ jobs:
             hashFiles('conda/environments/cgat-core.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*"
           python-version: ${{ matrix.python-version }}
           channels: conda-forge, bioconda, defaults
           channel-priority: true
           activate-environment: cgat-core
           environment-file: conda/environments/cgat-core.yml
+          miniforge-variant: Mambaforge
       - name: Show conda
         run: |
           conda info

--- a/.github/workflows/cgatcore_python.yml
+++ b/.github/workflows/cgatcore_python.yml
@@ -18,7 +18,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v
+      - uses: actions/checkout@v3
       - name: Cache conda
         uses: actions/cache@v3
         env:

--- a/cgatcore/iotools.py
+++ b/cgatcore/iotools.py
@@ -768,7 +768,7 @@ def is_nested(container):
     A nested data structure is a dict of dicts or a list of list,
     but not a dict of list or a list of dicts.
     """
-    for t in [collections.Mapping, list, tuple]:
+    for t in [collections.abc.Mapping, list, tuple]:
         if isinstance(container, t):
             return any([isinstance(v, t) for v in container.values()])
     return False
@@ -790,9 +790,9 @@ def nested_iter(nested):
         A container/key/value triple
     """
 
-    if isinstance(nested, collections.Mapping):
+    if isinstance(nested, collections.abc.Mapping):
         for key, value in nested.items():
-            if not isinstance(value, collections.Mapping) and \
+            if not isinstance(value, collections.abc.Mapping) and \
                not isinstance(value, list):
                 yield nested, key, value
             else:
@@ -800,7 +800,7 @@ def nested_iter(nested):
                     yield x
     elif isinstance(nested, list):
         for key, value in enumerate(nested):
-            if not isinstance(value, collections.Mapping) and \
+            if not isinstance(value, collections.abc.Mapping) and \
                not isinstance(value, list):
                 yield nested, key, value
             else:

--- a/cgatcore/iotools.py
+++ b/cgatcore/iotools.py
@@ -1365,7 +1365,7 @@ def text_to_dict(filename, key=None, sep="\t"):
                     fieldn += 1
             count += 1
 
-    return(result)
+    return result
 
 
 def pickle(file_name, obj):

--- a/cgatcore/pipeline/execution.py
+++ b/cgatcore/pipeline/execution.py
@@ -198,7 +198,7 @@ def get_conda_environment_directory(env_name):
         # registered with conda. NB this can't tellif the directory contains a
         # valid env.
         if os.path.exists(env_name) and os.path.isdir(env_name):
-            return(env_name)
+            return env_name
 
         raise IOError("conda environment {} does not exist, found {}".format(
             env_name, sorted(env_map.keys())))

--- a/cgatcore/pipeline/parameters.py
+++ b/cgatcore/pipeline/parameters.py
@@ -182,7 +182,7 @@ def config_to_dictionary(config):
 
 def nested_update(old, new):
     '''Update potentially nested dictionaries. If both old[x] and new[x]
-    inherit from collections.Mapping, then update old[x] with entries from
+    inherit from collections.abc.Mapping, then update old[x] with entries from
     new[x], otherwise set old[x] to new[x]'''
 
     for key, value in new.items():

--- a/cgatcore/tables.py
+++ b/cgatcore/tables.py
@@ -418,7 +418,7 @@ def join_tables(outfile, options, args):
                     outfile.write("\t".join(table[key]))
                     c = len(table[key])
 
-                assert(max_size == 1)
+                assert max_size == 1
 
                 outfile.write("\t%s" % options.missing_value * (max_size - c))
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -84,4 +84,4 @@ def test_import():
             if os.path.isdir(f):
                 continue
             check_import.description = os.path.abspath(f)
-            yield(check_import, os.path.abspath(f), outfile)
+            yield check_import, os.path.abspath(f), outfile

--- a/tests/test_iotools.py
+++ b/tests/test_iotools.py
@@ -51,5 +51,35 @@ class TestiotoolsTouchFileCompressed(TestiotoolsTouchFile):
     basename = "test_iotools_touch_file.txt.gz"
 
 
+class TestiottoolsIsNested(unittest.TestCase):
+
+    def test_is_nested_with_dict(self):
+        test_data = {
+            "key1": {
+                "nested_key1": "nested_key1"
+            }
+        }
+        self.assertTrue(iotools.is_nested(test_data))
+
+
+class TestiottoolsNestedIter(unittest.TestCase):
+
+    def test_nested_iter_with_dict_of_dicts(self):
+        test_data = {
+            "key1": {
+                "nested_key1": "nested_key1"
+            }
+        }
+        list(iotools.nested_iter(test_data))
+
+    def test_nested_iter_with_list_of_dicts(self):
+        test_data = [
+            {
+                "nested_key1": "nested_key1"
+            }
+        ]
+        list(iotools.nested_iter(test_data))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The cgat-core codebase was [recently](https://github.com/cgat-developers/cgat-core/pull/154) updated with support for python 3.10. However, some incompatibilities were inadvertently left in the code.

This PR will fix those.