### PR TITLE
Declare pipeline runtime dependencies

### DIFF
--- a/.github/workflows/cgatcore_python.yml
+++ b/.github/workflows/cgatcore_python.yml
@@ -3,6 +3,23 @@ name: cgatcore
 on: [push, pull_request]
 
 jobs:
+  clean-wheel-import:
+    name: Clean wheel import
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install from project metadata only
+        run: python -m pip install .
+
+      - name: Import the public pipeline interface
+        run: python -c "from cgatcore import pipeline as P; assert callable(P.initialize)"
+
   build:
     name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,14 @@ classifiers = [
     "Operating System :: MacOS"
 ]
 readme = "README.md"
+dependencies = [
+    "apsw",
+    "gevent",
+    "pandas",
+    "PyYAML",
+    "ruffus",
+    "SQLAlchemy",
+]
 
 [project.urls]
 Documentation = "https://github.com/cgat-developers/cgat-core"


### PR DESCRIPTION
Closes #210.

## What changed

- declare the six packages imported unconditionally by the public cgatcore.pipeline interface
- add an isolated CI job that installs from project metadata only and imports that interface

## Why

The 0.6.22 wheel has no runtime dependencies in project metadata. A clean install therefore fails before P.initialize can be used. Repository development requirement files hide this packaging gap.

## Verification

- built and installed the project into a fresh Python 3.11 venv
- imported cgatcore.pipeline and asserted P.initialize is callable
- pip check: no broken requirements
- pytest -q tests/test_import.py: one pre-existing environment failure because the downstream Oferta environment does not install the optional kubernetes module; the new clean public-interface smoke passes independently

## Compatibility

This changes installation metadata only; it does not change the pipeline API. Downstream projects can remove temporary direct declarations after a corrected CGATCore release is qualified.